### PR TITLE
Corrected index error in getRow and getColumn method.

### DIFF
--- a/java/matrix/src/main/java/Matrix.java
+++ b/java/matrix/src/main/java/Matrix.java
@@ -19,13 +19,13 @@ class Matrix {
     }
 
     int[] getRow(int rowNumber) {
-        return matrix[rowNumber];
+        return matrix[rowNumber - 1];
     }
 
     int[] getColumn(int columnNumber) {
         int[] col = new int[matrix.length];
         for (int i =  0; i < matrix.length; i++) {
-            col[i] = matrix[i][columnNumber];
+            col[i] = matrix[i][columnNumber - 1];
         }
         return col;
     }


### PR DESCRIPTION
The getRow and getColumn methods and using the human input index.

So the index starts from 1 for the first value, which in-turn should be pointing towards index=0.